### PR TITLE
Basic port to webextensions for firefox

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -11,13 +11,13 @@ var track = function(button, event){
 //-------------------//
 var submit = function(type, via, id, url, title){
   track(via+'_'+type);
-  chrome.tabs.sendRequest(id, {func: 'submit', url: url, title: title});
+  browser.tabs.sendMessage(id, {func: 'submit', url: url, title: title});
 };
 
 //--------------------//
 // Main Plugin Button //
 //--------------------//
-chrome.browserAction.onClicked.addListener(function(tab){
+browser.browserAction.onClicked.addListener(function(tab){
   submit('page', 'browserAction', tab.id, tab.url, tab.title);
 });
 
@@ -32,7 +32,7 @@ var contexts = [
   {type: "audio", func: function(info, tab){ submit('audio', 'contextMenu', tab.id, info.srcUrl); }}
 ];
 for(var i = 0; i < contexts.length; i++){
-  chrome.contextMenus.create({
+  browser.contextMenus.create({
     "title": "Post " + contexts[i].type + " to Reading",
     "contexts": [contexts[i].type],
     "onclick": contexts[i].func
@@ -43,7 +43,7 @@ for(var i = 0; i < contexts.length; i++){
 // CSP Bypass //
 //------------//
 // https://www.planbox.com/blog/development/coding/bypassing-githubs-content-security-policy-chrome-extension.html
-chrome.webRequest.onHeadersReceived.addListener(function(details) {
+browser.webRequest.onHeadersReceived.addListener(function(details) {
   for (i = 0; i < details.responseHeaders.length; i++) {
     if (['content-security-policy',
          'x-content-security-policy',

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -23,6 +23,11 @@
     "default_title": "Post this page to Reading",
     "default_icon": "shared/icon48.png"
   },
+  "applications": {
+    "gecko": {
+      "id": "reading.am@dinhe.net"
+    }
+  },
   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
   "content_scripts": [{
     "js": ["shared/content.js"],


### PR DESCRIPTION
This needs a small tweak to the shared script as in https://github.com/reading-am/reading-extensions-shared/pull/1

It will also need some decisions made, whether to extract the webextensions version into its own directory, or make it share with chrome with conditionals. This gets the extension working as in https://hacks.mozilla.org/2015/10/porting-chrome-extensions-to-firefox-with-webextensions/, but breaks Chrome as it stands. 